### PR TITLE
Replace deprecated pypy3 with pypy-3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11-dev", "3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["3.11-dev", "3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
         os: [
           ubuntu-20.04,
           ubuntu-18.04,


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos