### PR TITLE
Test CRLF: exact CPython repro

### DIFF
--- a/3.15.rst
+++ b/3.15.rst
@@ -942,6 +942,16 @@ pickle
   (Contributed by Zackery Spytz and Serhiy Storchaka in :gh:`77188`.)
 
 
+pprint
+------
+
+* Add *color* parameter to :func:`~pprint.pp` and :func:`~pprint.pprint`.
+  If ``True`` (the default), output is highlighted in color, when the stream
+  and :ref:`environment variables <using-on-controlling-color>` permit.
+  If ``False``, colored output is always disabled.
+  (Contributed by Hugo van Kemenade in :gh:`145217`.)
+
+
 re
 --
 


### PR DESCRIPTION
Reproducing the exact same conflict as python/cpython PR #145218 to test CRLF behaviour